### PR TITLE
Add .gitignore for Python 2.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+*.pyc
+*.swp
+*.DS_Store


### PR DESCRIPTION
It is recommended to add a `.gitignore` in order to help with `*.pyc` files, `*.swp` files of `vim(1)` and `.DS_Store` files of Mac OS X.